### PR TITLE
Added support for FrameworkContentElement (such as Run)

### DIFF
--- a/WPFLocalizeExtension/Extensions/LocExtension.cs
+++ b/WPFLocalizeExtension/Extensions/LocExtension.cs
@@ -287,7 +287,7 @@ namespace WPFLocalizeExtension.Extensions
                         break;
                     }
 #if !SILVERLIGHT
-                    if (!(doParent is Visual) && !(doParent is Visual3D))
+                    if (!(doParent is Visual) && !(doParent is Visual3D) && !(doParent is FrameworkContentElement))
                     {
                         UpdateNewValue();
                         break;
@@ -295,8 +295,12 @@ namespace WPFLocalizeExtension.Extensions
 #endif
                     try
                     {
-                        var doParent2 = VisualTreeHelper.GetParent(doParent);
-                        if (doParent2 == null && doParent is FrameworkElement)
+                      DependencyObject doParent2;
+                      if (doParent is FrameworkContentElement)
+                        doParent2 = ((FrameworkContentElement) doParent).Parent;
+                      else
+                        doParent2 = VisualTreeHelper.GetParent(doParent);
+                      if (doParent2 == null && doParent is FrameworkElement)
                             doParent2 = ((FrameworkElement)doParent).Parent;
 
                         doParent = doParent2;

--- a/WPFLocalizeExtension/Providers/ParentChangedNotifierHelper.cs
+++ b/WPFLocalizeExtension/Providers/ParentChangedNotifierHelper.cs
@@ -56,12 +56,17 @@ namespace WPFLocalizeExtension.Providers
 
                     // Try to get the parent using the visual tree helper. This may fail on some occations.
 #if !SILVERLIGHT
-                    if (!(depObj is Visual) && !(depObj is Visual3D))
+                    if (!(depObj is Visual) && !(depObj is Visual3D) && !(depObj is FrameworkContentElement))
                         break;
 #endif
                     DependencyObject depObjParent = null;
-                    try { depObjParent = VisualTreeHelper.GetParent(depObj); }
-                    catch { break; }
+                    if (depObj is FrameworkContentElement)
+                      depObjParent = ((FrameworkContentElement)depObj).Parent;
+                    else
+                    {
+                      try { depObjParent = VisualTreeHelper.GetParent(depObj); }
+                      catch { break; }
+                    }
                     // If this failed, try again using the Parent property (sometimes this is not covered by the VisualTreeHelper class :-P.
                     if (depObjParent == null && depObj is FrameworkElement)
                         depObjParent = ((FrameworkElement)depObj).Parent;
@@ -117,12 +122,17 @@ namespace WPFLocalizeExtension.Providers
 
                     // Try to get the parent using the visual tree helper. This may fail on some occations.
 #if !SILVERLIGHT
-                    if (!(depObj is Visual) && !(depObj is Visual3D))
+                    if (!(depObj is Visual) && !(depObj is Visual3D) && !(depObj is FrameworkContentElement))
                         break;
 #endif
                     DependencyObject depObjParent = null;
-                    try { depObjParent = VisualTreeHelper.GetParent(depObj); }
-                    catch { break; }
+                    if (depObj is FrameworkContentElement)
+                      depObjParent = ((FrameworkContentElement)depObj).Parent;
+                    else
+                    {
+                      try { depObjParent = VisualTreeHelper.GetParent(depObj); }
+                      catch { break; }
+                    }
                     // If this failed, try again using the Parent property (sometimes this is not covered by the VisualTreeHelper class :-P.
                     if (depObjParent == null && depObj is FrameworkElement)
                         depObjParent = ((FrameworkElement)depObj).Parent;


### PR DESCRIPTION
If you use FrameworkContentElements (ie Run), then you must explicitly set Assembly:Dictionary:Key. This fixes the need for that workaround
