### PR TITLE
Add Reset method to ResxLocationProvider (Useful for test isolation)

### DIFF
--- a/WPFLocalizeExtension/Providers/ResxLocalizationProvider.cs
+++ b/WPFLocalizeExtension/Providers/ResxLocalizationProvider.cs
@@ -150,6 +150,14 @@ namespace WPFLocalizeExtension.Providers
                 return instance;
             }
         }
+		
+		/// <summary>
+        /// Resets the instance that is used for the ResxLocationProvider
+        /// </summary>
+        public static void Reset()
+       {
+          instance = null;
+       }
 
         /// <summary>
         /// The singleton constructor.


### PR DESCRIPTION
When running tests where different tests had created controls already,
cross thread exceptions would occur
