### PR TITLE
Enhanced fallback behaviour for ResxLocalizationProvider.

### DIFF
--- a/WPFLocalizeExtension/Providers/ResxLocalizationProvider.cs
+++ b/WPFLocalizeExtension/Providers/ResxLocalizationProvider.cs
@@ -41,7 +41,7 @@ namespace WPFLocalizeExtension.Providers
                 "DefaultDictionary",
                 typeof(string),
                 typeof(ResxLocalizationProvider),
-                new PropertyMetadata(null, AttachedPropertyChanged));
+                new PropertyMetadata(null, DefaultDictionaryChanged));
 
         /// <summary>
         /// <see cref="DependencyProperty"/> DefaultAssembly to set the fallback assembly.
@@ -51,17 +51,29 @@ namespace WPFLocalizeExtension.Providers
                 "DefaultAssembly",
                 typeof(string),
                 typeof(ResxLocalizationProvider),
-                new PropertyMetadata(null, AttachedPropertyChanged));
+                new PropertyMetadata(null, DefaultAssemblyChanged));
         #endregion
 
         #region Dependency Property Callback
         /// <summary>
-        /// Indicates, that one of the attached properties changed.
+        /// Indicates, that the <see cref="DefaultDictionaryProperty"/> attached property changed.
         /// </summary>
         /// <param name="obj">The dependency object.</param>
-        /// <param name="args">The event argument.</param>
-        private static void AttachedPropertyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs args)
+        /// <param name="e">The event argument.</param>
+        private static void DefaultDictionaryChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
         {
+            Instance.FallbackDictionary = e.NewValue != null ? e.NewValue.ToString() : null;
+            Instance.OnProviderChanged(obj);
+        }
+
+        /// <summary>
+        /// Indicates, that the <see cref="DefaultAssemblyProperty"/> attached property changed.
+        /// </summary>
+        /// <param name="obj">The dependency object.</param>
+        /// <param name="e">The event argument.</param>
+        private static void DefaultAssemblyChanged(DependencyObject obj, DependencyPropertyChangedEventArgs e)
+        {
+            Instance.FallbackAssembly = e.NewValue != null ? e.NewValue.ToString() : null;
             Instance.OnProviderChanged(obj);
         }
         #endregion


### PR DESCRIPTION
Hi!

In one of our projects we use the WPFLocalizationExtension in combination with the XamDataGrid of Infragistics. We tried to use the LocTex extension for providing the label-text of a column. 
Unfortunately it did not work and we always got the fallback “key:resource_key”. 

After a little bit of debugging we found out, that the ResxLocalizationProvider was not able to locate our default assembly and dictionary. These two default values are set in our main window. The ResxLocalizationProvider did not find the default values because of the implementation within the ParentChangedNotifierHelper. The GetValueOrRegisterParentNotifier tries to find the values for ResxLocalizationProvider.DefaultAssembly and ResxLocalizationProvider.DefaultDictionary by traveling up the visual tree. In case of the XamDataGrid, the fields are not part of the generated visual tree nor are they Visuals at all. They are simple DependencyObjects and are used to generate the final column-layout.

While debugging the code we found out, that it would be sufficient to set the FallbackAssembly and FallbackDictionary. I did that in the callbacks for attached properties within the ResxLocalizationProvider class and it worked.
