### PR TITLE
Update CultureInfoDelegateCommand class

### DIFF
--- a/WPFLocalizeExtension/Engine/LocalizeDictionary.cs
+++ b/WPFLocalizeExtension/Engine/LocalizeDictionary.cs
@@ -1250,7 +1250,7 @@ namespace WPFLocalizeExtension.Engine
             /// <param name="parameter">Data used by the command. If the command does not require data to be passed, this object can be set to null.</param>
             public void Execute(object parameter)
             {
-                var c = new CultureInfo((string)parameter);
+                var c = (CultureInfo)parameter;
                 this.execute(c);
             }
             #endregion


### PR DESCRIPTION
The `Execute` method should cast `parameter` directly to `CultureInfo`, not to `String`. Passed parameter is already a `CultureInfo`.