### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 	* Implements INotifyPropertyChanged for advanced use
 	* Offers some functionality to check and get resource values in code behind (e.g. ResolveLocalizedValue)
 * Easy to use
-	* Can be used with any resource file (.resx) accross all assemblies (also the dynamic loaded one at runtime)
+	* Can be used with any resource file (.resx) across all assemblies (also the dynamic loaded one at runtime)
 	* Does not need any initializing process (like "call xyz to register a special localize dictionary")
 	* Can localize any type of data type, as long a TypeConverter exists for it
 * Example extensions included for


### PR DESCRIPTION
@SeriousM, I've corrected a typographical error in the documentation of the [WPFLocalizationExtension](https://github.com/SeriousM/WPFLocalizationExtension) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.