### PR TITLE
Make ResxLocalizationProvider possible to subclass

### DIFF
--- a/WPFLocalizeExtension/Providers/ResxLocalizationProvider.cs
+++ b/WPFLocalizeExtension/Providers/ResxLocalizationProvider.cs
@@ -203,23 +203,28 @@ namespace WPFLocalizeExtension.Providers
                 // return the existing/new instance
                 return _instance;
             }
+
+            set
+            {
+                lock (InstanceLock)
+                {
+                    _instance = value;
+                }
+            }
         }
-		
-		/// <summary>
+
+        /// <summary>
         /// Resets the instance that is used for the ResxLocationProvider
         /// </summary>
         public static void Reset()
         {
-            lock (InstanceLock)
-            {
-                _instance = null;
-            }
+            Instance = null;
         }
 
         /// <summary>
         /// The singleton constructor.
         /// </summary>
-        private ResxLocalizationProvider()
+        protected ResxLocalizationProvider()
         {
             ResourceManagerList = new Dictionary<string, ResourceManager>();
             AvailableCultures = new ObservableCollection<CultureInfo> {CultureInfo.InvariantCulture};


### PR DESCRIPTION
Fix #126 
I've made changed to `ResxLocalizationProvider`:
- ctor protected,
- Instance set,
- `GetFullyQualifiedResourceKey` virtual,
- `GetLocalizedObject` uses the `GetFullyQualifiedResourceKey` to avoid copy&paste of code.