### PR TITLE
Instance per Thread

### DIFF
--- a/src/Engine/InstanceLocator.cs
+++ b/src/Engine/InstanceLocator.cs
@@ -153,7 +153,7 @@ namespace WPFLocalizeExtension.Engine
     }
 
     /// <summary>
-    /// 
+    /// A empty interface - just to indicate a class is useable for the thread / instance logic
     /// </summary>
     public interface ILocalizeInstance
     {

--- a/src/Engine/InstanceLocator.cs
+++ b/src/Engine/InstanceLocator.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Windows;
+using System.Windows.Threading;
+
+namespace WPFLocalizeExtension.Engine
+{
+    internal static class InstanceLocator
+    {
+        /// <summary>
+        /// Holds a SyncRoot to be thread safe
+        /// </summary>
+        private static readonly object SyncRoot = new object();
+
+        /// <summary>
+        /// Holds the threaded instances per type
+        /// </summary>
+        private static Dictionary<Type, Dictionary<int, object>> _instances = new Dictionary<Type, Dictionary<int, object>>();
+
+        /// <summary>
+        /// Get a singleton or per thread instance
+        /// </summary>
+        /// <typeparam name="T">Type of the requested instance. Has to implement a public parameterless constructor.</typeparam>
+        /// <returns>instance of type <typeparamref name="T"/></returns>
+        public static T Resolve<T>() where T : class, new()
+        {
+            var instances = GetTypeInstances<T>();
+            return GetInstance<T>(instances);
+        }
+
+        /// <summary>
+        /// Get a singleton or per thread instance
+        /// </summary>
+        /// <param name="type">Type of the requested instance. Has to implement a public parameterless constructor.</param>
+        /// <returns>instance of <paramref name="type"/></returns>
+        public static object Resolve(Type type)
+        {
+            var instances = GetTypeInstances(type);
+            return GetInstance(instances, type);
+        }
+
+        /// <summary>
+        /// Get the instance dictionary for <typeparamref name="T"/>
+        /// </summary>
+        /// <typeparam name="T">instance type</typeparam>
+        /// <returns>The new / existing instance collection for the requested type</returns>
+        public static Dictionary<int, object> GetTypeInstances<T>() where T : class
+        {
+            var type = typeof(T);
+            return GetTypeInstances(type);
+        }
+
+        /// <summary>
+        /// Get the instance dictionary for <paramref name="type"/>
+        /// </summary>
+        /// <param name="type">instance type</param>
+        /// <returns>The new / existing instance collection for the requested type</returns>
+        public static Dictionary<int, object> GetTypeInstances(Type type)
+        {
+            if (!_instances.ContainsKey(type))
+            {
+                lock (SyncRoot)
+                {
+                    _instances.Add(type, new Dictionary<int, object>());
+                }
+            }
+
+            return _instances[type];
+        }
+
+        /// <summary>
+        /// Get a instance of type <typeparamref name="T"/>
+        /// </summary>
+        /// <typeparam name="T">instance type</typeparam>
+        /// <param name="instances">instances dictionary</param>
+        /// <returns>The new / existing instance of type <typeparamref name="T"/></returns>
+        private static T GetInstance<T>(Dictionary<int, object> instances) where T : class, new()
+        {
+            return GetInstance(instances, typeof(T)) as T;
+        }
+
+        /// <summary>
+        /// Get a instance of <paramref name="type"/>
+        /// </summary>
+        /// <param name="instances">instances dictionary</param>
+        /// <param name="type">instance type</param>
+        /// <returns>The new / existing instance of type <paramref name="type"/></returns>
+        private static object GetInstance(Dictionary<int, object> instances, Type type)
+        {
+            object result = null;
+            var threadId = Thread.CurrentThread.ManagedThreadId;
+
+            // when UseThreadInstances is activated the requested type has to implement the ILocalizeInstance interface
+            // otherwise we will use a singleton instance
+            if (LocalizeSettings.Instance.UseThreadInstances && typeof(ILocalizeInstance).IsAssignableFrom(type))
+            {
+                if (instances.ContainsKey(threadId))
+                    result = instances[threadId];
+            }
+            else
+                result = instances.FirstOrDefault().Value;
+
+            if (result == null)
+            {
+                lock (SyncRoot)
+                {
+                    result = Activator.CreateInstance(type);
+                    CheckShutdownEvent(Thread.CurrentThread);
+                    instances.Add(threadId, result);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Check if the provided thread populates a dispatcher object, subsribe to the <see cref="Dispatcher.ShutdownStarted"/> event and dissolve instances for this thread.
+        /// </summary>
+        /// <param name="thread"></param>
+        private static void CheckShutdownEvent(Thread thread)
+        {
+            var dis = Dispatcher.FromThread(thread);
+            if (dis != null && !_instances.Any(x => x.Value.Any(y => y.Key == thread.ManagedThreadId)))
+            {
+                dis.ShutdownStarted += (o, e) =>
+                {
+                    foreach (var entry in _instances.SelectMany(x => x.Value.Where(y => y.Key == thread.ManagedThreadId)).ToList())
+                        Dissolve(entry.Value);
+                };
+            }
+        }
+
+        /// <summary>
+        /// Remove a instance from the collection
+        /// </summary>
+        /// <param name="obj">instance</param>
+        internal static void Dissolve(object obj)
+        {
+            var instances = GetTypeInstances(obj.GetType());
+            if (instances.Any(x => x.Value == obj))
+            {
+                var entry = instances.Single(x => x.Value == obj);
+                lock (SyncRoot)
+                {
+                    instances.Remove(entry.Key);
+                }
+            }
+
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface ILocalizeInstance
+    {
+
+    }
+}

--- a/src/Engine/InstanceLocator.cs
+++ b/src/Engine/InstanceLocator.cs
@@ -154,8 +154,5 @@ namespace WPFLocalizeExtension.Engine
     /// <summary>
     /// A empty interface - just to indicate a class is useable for the thread / instance logic
     /// </summary>
-    public interface ILocalizeInstance
-    {
-    
-    }
+    public interface ILocalizeInstance { }
 }

--- a/src/Engine/InstanceLocator.cs
+++ b/src/Engine/InstanceLocator.cs
@@ -148,7 +148,6 @@ namespace WPFLocalizeExtension.Engine
                     instances.Remove(entry.Key);
                 }
             }
-
         }
     }
 
@@ -157,6 +156,6 @@ namespace WPFLocalizeExtension.Engine
     /// </summary>
     public interface ILocalizeInstance
     {
-
+    
     }
 }

--- a/src/Engine/LocalizeDictionary.cs
+++ b/src/Engine/LocalizeDictionary.cs
@@ -41,7 +41,7 @@ namespace WPFLocalizeExtension.Engine
     /// <summary>
     /// Represents the culture interface for localization
     /// </summary>
-    public sealed class LocalizeDictionary : DependencyObject, INotifyPropertyChanged
+    public sealed class LocalizeDictionary : DependencyObject, INotifyPropertyChanged, ILocalizeInstance
     {
         #region INotifyPropertyChanged Implementation
         /// <summary>
@@ -102,7 +102,7 @@ namespace WPFLocalizeExtension.Engine
                 "Separation",
                 typeof(string),
                 typeof(LocalizeDictionary),
-                new PropertyMetadata(DefaultSeparation, SetSeparationFromDependencyProperty));
+                new PropertyMetadata(LocalizeSettings.Instance.Separation, SetSeparationFromDependencyProperty));
 
         /// <summary>
         /// A flag indicating that the invariant culture should be included.
@@ -112,7 +112,7 @@ namespace WPFLocalizeExtension.Engine
                 "IncludeInvariantCulture",
                 typeof(bool),
                 typeof(LocalizeDictionary),
-                new PropertyMetadata(true, SetIncludeInvariantCultureFromDependencyProperty));
+                new PropertyMetadata(LocalizeSettings.Instance.IncludeInvariantCulture, SetIncludeInvariantCultureFromDependencyProperty));
 
         /// <summary>
         /// A flag indicating that the cache is disabled.
@@ -122,7 +122,7 @@ namespace WPFLocalizeExtension.Engine
                 "DisableCache",
                 typeof(bool),
                 typeof(LocalizeDictionary),
-                new PropertyMetadata(false, SetDisableCacheFromDependencyProperty));
+                new PropertyMetadata(LocalizeSettings.Instance.DisableCache, SetDisableCacheFromDependencyProperty));
 
         /// <summary>
         /// A flag indicating that missing keys should be output.
@@ -132,7 +132,7 @@ namespace WPFLocalizeExtension.Engine
                 "OutputMissingKeys",
                 typeof(bool),
                 typeof(LocalizeDictionary),
-                new PropertyMetadata(true, SetOutputMissingKeysFromDependencyProperty));
+                new PropertyMetadata(LocalizeSettings.Instance.OutputMissingKeys, SetOutputMissingKeysFromDependencyProperty));
         #endregion
 
         #region Dependency Property Callbacks
@@ -420,11 +420,6 @@ namespace WPFLocalizeExtension.Engine
         private static readonly object SyncRoot = new object();
 
         /// <summary>
-        /// Holds the instance of singleton
-        /// </summary>
-        private static LocalizeDictionary _instance;
-
-        /// <summary>
         /// Holds the current chosen <see cref="CultureInfo"/>
         /// </summary>
         private CultureInfo _culture;
@@ -432,22 +427,22 @@ namespace WPFLocalizeExtension.Engine
         /// <summary>
         /// Holds the separation char/string.
         /// </summary>
-        private string _separation = DefaultSeparation;
+        private string _separation = LocalizeSettings.Instance.Separation;
 
         /// <summary>
         /// Determines, if the <see cref="MergedAvailableCultures"/> contains the invariant culture.
         /// </summary>
-        private bool _includeInvariantCulture = true;
+        private bool _includeInvariantCulture = LocalizeSettings.Instance.IncludeInvariantCulture;
 
         /// <summary>
         /// Determines, if the cache is disabled.
         /// </summary>
-        private bool _disableCache = true;
+        private bool _disableCache = LocalizeSettings.Instance.DisableCache;
 
         /// <summary>
         /// Determines, if missing keys should be output.
         /// </summary>
-        private bool _outputMissingKeys = true;
+        private bool _outputMissingKeys = LocalizeSettings.Instance.OutputMissingKeys;
 
         /// <summary>
         /// A default provider.
@@ -457,7 +452,7 @@ namespace WPFLocalizeExtension.Engine
         /// <summary>
         /// Determines, if the CurrentThread culture is set along with the Culture property.
         /// </summary>
-        private bool _setCurrentThreadCulture = true;
+        private bool _setCurrentThreadCulture = LocalizeSettings.Instance.SetCurrentThreadCulture;
 
         /// <summary>
         /// Determines if the code is run in DesignMode or not.
@@ -471,10 +466,10 @@ namespace WPFLocalizeExtension.Engine
         /// Prevents a default instance of the <see cref="T:WPFLocalizeExtension.Engine.LocalizeDictionary" /> class from being created.
         /// Static Constructor
         /// </summary>
-        private LocalizeDictionary()
+        public LocalizeDictionary()
         {
-            DefaultProvider = ResxLocalizationProvider.Instance;
-            SetCultureCommand = new CultureInfoDelegateCommand(SetCulture);
+            DefaultProvider = InstanceLocator.Resolve(LocalizeSettings.Instance.LocalizationProviderType) as ILocalizationProvider;
+            SetCultureCommand = new CultureInfoDelegateCommand((c) => LocalizeSettings.Instance.Culture = c);
         }
 
         private void AvailableCulturesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -509,9 +504,14 @@ namespace WPFLocalizeExtension.Engine
         /// </summary>
         ~LocalizeDictionary()
         {
-            LocExtension.ClearResourceBuffer();
-            FELoc.ClearResourceBuffer();
-            BLoc.ClearResourceBuffer();
+			// do not clear the resource buffer on multi threaded applications
+            if (!LocalizeSettings.Instance.UseThreadInstances)
+            {
+                LocExtension.ClearResourceBuffer();
+                FELoc.ClearResourceBuffer();
+                BLoc.ClearResourceBuffer();
+            }
+            InstanceLocator.Dissolve(this);
         }
         #endregion
 
@@ -522,11 +522,6 @@ namespace WPFLocalizeExtension.Engine
         public static CultureInfo DefaultCultureInfo => CultureInfo.InvariantCulture;
 
         /// <summary>
-        /// Gets the default separation char/string.
-        /// </summary>
-        public static string DefaultSeparation => "_";
-
-        /// <summary>
         /// Gets the <see cref="LocalizeDictionary"/> singleton.
         /// If the underlying instance is null, a instance will be created.
         /// </summary>
@@ -534,26 +529,8 @@ namespace WPFLocalizeExtension.Engine
         {
             get
             {
-                // check if the underlying instance is null
-                if (_instance == null)
-                {
-                    // if it is null, lock the syncroot.
-                    // if another thread is accessing this too,
-                    // it have to wait until the syncroot is released
-                    lock (SyncRoot)
-                    {
-                        // check again, if the underlying instance is null
-                        if (_instance == null)
-                        {
-                            // create a new instance
-                            _instance = new LocalizeDictionary();
-                        }
-                    }
-                }
-
-                // return the existing/new instance
-                return _instance;
-            }
+				return InstanceLocator.Resolve<LocalizeDictionary>();
+			}
         }
 
         /// <summary>
@@ -972,13 +949,21 @@ namespace WPFLocalizeExtension.Engine
         #endregion
 
         #region DictionaryEvent (using weak references)
-        internal static class DictionaryEvent
+        internal class DictionaryEvent : ILocalizeInstance
         {
             /// <summary>
             /// The list of listeners
             /// </summary>
-            private static readonly List<WeakReference> Listeners = new List<WeakReference>();
-            private static readonly object ListenersLock = new object();
+            private readonly List<WeakReference> Listeners = new List<WeakReference>();
+            private readonly object ListenersLock = new object();
+
+            private static DictionaryEvent Instance
+            {
+                get
+                {
+                    return InstanceLocator.Resolve<DictionaryEvent>();
+                }
+            }
 
             /// <summary>
             /// Fire the event.
@@ -988,16 +973,17 @@ namespace WPFLocalizeExtension.Engine
             internal static void Invoke(DependencyObject sender, DictionaryEventArgs args)
             {
                 var list = new List<IDictionaryEventListener>();
+                var instance = Instance;
 
-                lock (ListenersLock)
+                lock (instance.ListenersLock)
                 {
-                    foreach (var wr in Listeners.ToList())
+                    foreach (var wr in instance.Listeners.ToList())
                     {
                         var targetReference = wr.Target;
                         if (targetReference != null)
                             list.Add((IDictionaryEventListener)targetReference);
                         else
-                            Listeners.Remove(wr);
+                            instance.Listeners.Remove(wr);
                     }
                 }
 
@@ -1014,23 +1000,25 @@ namespace WPFLocalizeExtension.Engine
                 if (listener == null)
                     return;
 
+                var instance = Instance;
+
                 // Check, if this listener already was added.
                 bool listenerExists = false;
 
-                lock (ListenersLock)
+                lock (instance.ListenersLock)
                 {
-                    foreach (var wr in Listeners.ToList())
+                    foreach (var wr in instance.Listeners.ToList())
                     {
                         var targetReference = wr.Target;
                         if (targetReference == null)
-                            Listeners.Remove(wr);
+                            instance.Listeners.Remove(wr);
                         else if (targetReference == listener)
                             listenerExists = true;
                     }
 
                     // Add it now.
                     if (!listenerExists)
-                        Listeners.Add(new WeakReference(listener));
+                        instance.Listeners.Add(new WeakReference(listener));
                 }
             }
 
@@ -1043,15 +1031,17 @@ namespace WPFLocalizeExtension.Engine
                 if (listener == null)
                     return;
 
-                lock (ListenersLock)
+                var instance = Instance;
+
+                lock (instance.ListenersLock)
                 {
-                    foreach (var wr in Listeners.ToList())
+                    foreach (var wr in instance.Listeners.ToList())
                     {
                         var targetReference = wr.Target;
                         if (targetReference == null)
-                            Listeners.Remove(wr);
+                            instance.Listeners.Remove(wr);
                         else if ((IDictionaryEventListener)targetReference == listener)
-                            Listeners.Remove(wr);
+                            instance.Listeners.Remove(wr);
                     }
                 }
             }
@@ -1063,14 +1053,15 @@ namespace WPFLocalizeExtension.Engine
             /// <returns>An enumeration of listeners.</returns>
             internal static IEnumerable<T> EnumerateListeners<T>()
             {
-                lock (ListenersLock)
+                var instance = Instance;
+                lock (instance.ListenersLock)
                 {
-                    foreach (var wr in Listeners.ToList())
+                    foreach (var wr in instance.Listeners.ToList())
                     {
                         var targetReference = wr.Target;
 
                         if (targetReference == null)
-                            Listeners.Remove(wr);
+                            instance.Listeners.Remove(wr);
                         else if (targetReference is T)
                             yield return (T)targetReference;
                     }
@@ -1080,11 +1071,6 @@ namespace WPFLocalizeExtension.Engine
         #endregion
 
         #region CultureInfoDelegateCommand
-        private void SetCulture(CultureInfo c)
-        {
-            Culture = c;
-        }
-
         /// <summary>
         /// A class for culture commands.
         /// </summary>

--- a/src/Engine/LocalizeSettings.cs
+++ b/src/Engine/LocalizeSettings.cs
@@ -478,8 +478,6 @@ namespace WPFLocalizeExtension.Engine
             {
                 return InstanceLocator.GetTypeInstances<LocalizeDictionary>().Select(x => x.Value as LocalizeDictionary).ToList();
             }
-
-
             #endregion
         }
         #endregion

--- a/src/Engine/LocalizeSettings.cs
+++ b/src/Engine/LocalizeSettings.cs
@@ -1,0 +1,487 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Windows;
+using WPFLocalizeExtension.Providers;
+
+namespace WPFLocalizeExtension.Engine
+{
+    /// <summary>
+    /// A class to hold all global settings
+    /// </summary>
+    public sealed class LocalizeSettings
+    {
+        #region Attached Dependency Properties
+        /// <summary>
+        /// A flag indicating to use singleton or per thread based instance
+        /// </summary>
+        public static readonly DependencyProperty UseThreadInstancesProperty =
+            DependencyProperty.RegisterAttached("UseThreadInstances", typeof(bool), typeof(LocalizeSettings), new PropertyMetadata(Settings.DefaultUseThreadInstances, UseThreadInstancesChangedCallback));
+
+        /// <summary>
+        /// <see cref="DependencyProperty"/> to set the localization Culture
+        /// </summary>
+        public static readonly DependencyProperty CultureProperty =
+            DependencyProperty.RegisterAttached("Culture", typeof(CultureInfo), typeof(LocalizeSettings), new PropertyMetadata(null, CultureChangedCallback));
+
+        /// <summary>
+        /// A flag indicating that the cache is disabled.
+        /// </summary>
+        public static readonly DependencyProperty DisableCacheProperty =
+            DependencyProperty.RegisterAttached("DisableCache", typeof(bool), typeof(LocalizeSettings), new PropertyMetadata(Settings.DefaultDisableCache, DisableCacheChangedCallback));
+
+        /// <summary>
+        /// A flag indicating that the invariant culture should be included.
+        /// </summary>
+        public static readonly DependencyProperty IncludeInvariantCultureProperty =
+            DependencyProperty.RegisterAttached("IncludeInvariantCulture", typeof(bool), typeof(LocalizeSettings), new PropertyMetadata(Settings.DefaultIncludeInvariantCulture, IncludeInvariantCultureChangedCallback));
+
+        /// <summary>
+        /// A flag indicating that missing keys should be output.
+        /// </summary>
+        public static readonly DependencyProperty OutputMissingKeysProperty =
+            DependencyProperty.RegisterAttached("OutputMissingKeys", typeof(bool), typeof(LocalizeSettings), new PropertyMetadata(Settings.DefaultOutputMissingKeys, OutputMissingKeysChangedCallback));
+
+        /// <summary>
+        /// <see cref="DependencyProperty"/> to set the separation character/string for resource name patterns.
+        /// </summary>
+        public static readonly DependencyProperty SeparationProperty =
+            DependencyProperty.RegisterAttached("Separation", typeof(string), typeof(LocalizeSettings), new PropertyMetadata(Settings.DefaultSeparation, SeparationChangedCallback));
+
+        /// <summary>
+        /// <see cref="DependencyProperty"/> to set the default <see cref="ILocalizationProvider"/> type.
+        /// </summary>
+        public static readonly DependencyProperty LocalizationProviderTypeProperty =
+            DependencyProperty.RegisterAttached("LocalizationProviderType", typeof(Type), typeof(LocalizeSettings), new PropertyMetadata(Settings.DefaultLocalizatinProviderType, LocalizationProviderTypeChangedCallback));
+
+        #endregion
+
+        #region Attached Dependency Properties Management
+        /// <summary>
+        /// Get <see cref="Settings.UseThreadInstances"/>
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns><see cref="Settings.UseThreadInstances"/></returns>
+        public static bool GetUseThreadInstances(DependencyObject obj)
+        {
+            return Instance.UseThreadInstances;
+        }
+
+        /// <summary>
+        /// Set <see cref="Settings.UseThreadInstances"/>
+        /// </summary>
+        /// <param name="obj">not used</param>
+        /// <param name="value"></param>
+        public static void SetUseThreadInstances(DependencyObject obj, bool value)
+        {
+            Instance.UseThreadInstances = value;
+        }
+
+        /// <summary>
+        /// Get <see cref="Settings.Culture"/>
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns><see cref="Settings.Culture"/></returns>
+        public static CultureInfo GetCulture(DependencyObject obj)
+        {
+            return Instance.Culture;
+        }
+
+        /// <summary>
+        /// Set <see cref="Settings.Culture"/>
+        /// </summary>
+        /// <param name="obj">not used</param>
+        /// <param name="value"></param>
+        public static void SetCulture(DependencyObject obj, CultureInfo value)
+        {
+            Instance.Culture = value;
+        }
+
+        /// <summary>
+        /// Get <see cref="Settings.DisableCache"/>
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns><see cref="Settings.DisableCache"/></returns>
+        public static bool GetDisableCache(DependencyObject obj)
+        {
+            return Instance.DisableCache;
+        }
+
+        /// <summary>
+        /// Set <see cref="Settings.DisableCache"/>
+        /// </summary>
+        /// <param name="obj">not used</param>
+        /// <param name="value"></param>
+        public static void SetDisableCache(DependencyObject obj, bool value)
+        {
+            Instance.DisableCache = value;
+        }
+
+        /// <summary>
+        /// Get <see cref="Settings.IncludeInvariantCulture"/>
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns><see cref="Settings.IncludeInvariantCulture"/></returns>
+        public static bool GetIncludeInvariantCulture(DependencyObject obj)
+        {
+            return (bool)obj.GetValue(IncludeInvariantCultureProperty);
+        }
+
+        /// <summary>
+        /// Set <see cref="Settings.IncludeInvariantCulture"/>
+        /// </summary>
+        /// <param name="obj">not used</param>
+        /// <param name="value"></param>
+        public static void SetIncludeInvariantCulture(DependencyObject obj, bool value)
+        {
+            obj.SetValue(IncludeInvariantCultureProperty, value);
+        }
+
+        /// <summary>
+        /// Get <see cref="Settings.OutputMissingKeys"/>
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns><see cref="Settings.OutputMissingKeys"/></returns>
+        public static bool GetOutputMissingKeys(DependencyObject obj)
+        {
+            return Instance.OutputMissingKeys;
+        }
+
+        /// <summary>
+        /// Set <see cref="Settings.OutputMissingKeys"/>
+        /// </summary>
+        /// <param name="obj">not used</param>
+        /// <param name="value"></param>
+        public static void SetOutputMissingKeys(DependencyObject obj, bool value)
+        {
+            Instance.OutputMissingKeys = value;
+        }
+
+        /// <summary>
+        /// Get <see cref="Settings.Separation"/>
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns><see cref="Settings.Separation"/></returns>
+        public static string GetSeparation(DependencyObject obj)
+        {
+            return Instance.Separation;
+        }
+
+        /// <summary>
+        /// Set <see cref="Settings.Separation"/>
+        /// </summary>
+        /// <param name="obj">not used</param>
+        /// <param name="value"></param>
+        public static void SetSeparation(DependencyObject obj, string value)
+        {
+            Instance.Separation = value;
+        }
+
+        /// <summary>
+        /// Get <see cref="Settings.LocalizationProviderType"/>
+        /// </summary>
+        /// <param name="obj"></param>
+        /// <returns><see cref="Settings.LocalizationProviderType"/></returns>
+        public static Type GetLocalizationProviderType(DependencyObject obj)
+        {
+            return Instance.LocalizationProviderType;
+        }
+
+        /// <summary>
+        /// Set <see cref="Settings.LocalizationProviderType"/>
+        /// </summary>
+        /// <param name="obj">not used</param>
+        /// <param name="value"></param>
+        public static void SetLocalizationProviderType(DependencyObject obj, Type value)
+        {
+            Instance.LocalizationProviderType = value;
+        }
+        #endregion
+
+        #region Attached Dependency Properties Callback
+        private static void UseThreadInstancesChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is bool b)
+                Instance.UseThreadInstances = b;
+        }
+
+        private static void CultureChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is CultureInfo c)
+                Instance.Culture = c;
+        }
+
+        private static void DisableCacheChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is bool b)
+                Instance.DisableCache = b;
+        }
+
+        private static void IncludeInvariantCultureChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is bool b)
+                Instance.IncludeInvariantCulture = b;
+        }
+
+        private static void OutputMissingKeysChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is bool b)
+                Instance.OutputMissingKeys = b;
+        }
+
+        private static void SeparationChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is string s)
+                Instance.Separation = s;
+        }
+
+        private static void LocalizationProviderTypeChangedCallback(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            if (e.NewValue is Type t)
+                Instance.LocalizationProviderType = t;
+        }
+        #endregion
+
+        #region Static Properties
+
+        private static Settings _instance;
+
+        /// <summary>
+        /// Singleton settings instance
+        /// </summary>
+        public static Settings Instance
+        {
+            get
+            {
+                return _instance ?? (_instance = new Settings());
+            }
+        }
+        #endregion
+
+        #region Settings Class
+        /// <summary>
+        /// Global settings class
+        /// </summary>
+        public class Settings
+        {
+            /// <summary>
+            /// protected constructor
+            /// </summary>
+            internal Settings() { }
+
+            #region Default values
+            /// <summary>
+            /// The default separation key for <see cref="Separation"/>
+            /// </summary>
+            public const string DefaultSeparation = "_";
+
+            /// <summary>
+            /// Default value for <see cref="UseThreadInstances"/>
+            /// </summary>
+            public const bool DefaultUseThreadInstances = false;
+
+            /// <summary>
+            /// Default value for <see cref="DisableCache"/>
+            /// </summary>
+            public const bool DefaultDisableCache = false;
+
+            /// <summary>
+            /// Default value for <see cref="IncludeInvariantCulture"/>
+            /// </summary>
+            public const bool DefaultIncludeInvariantCulture = true;
+
+            /// <summary>
+            /// Default value for <see cref="OutputMissingKeys"/>
+            /// </summary>
+            public const bool DefaultOutputMissingKeys = true;
+
+            /// <summary>
+            /// Default type for <see cref="LocalizationProviderType"/>
+            /// </summary>
+            public static readonly Type DefaultLocalizatinProviderType = typeof(ResxLocalizationProvider);
+            #endregion
+
+            #region Private Properties
+            private CultureInfo _culture;
+            private bool _disableCache = DefaultDisableCache;
+            private bool _includeInvariantCulture = DefaultIncludeInvariantCulture;
+            private bool _outputMissingKeys = DefaultOutputMissingKeys;
+            private string _separation = DefaultSeparation;
+            private Type _LocalizationProviderType = DefaultLocalizatinProviderType;
+            private bool _setCurrentThreadCulture = true;
+
+            #endregion
+
+            #region Public Properties
+            /// <summary>
+            /// A flag to determine the behaivor of this application on multithreaded applications.
+            /// When set to false a singleton instances will be used
+            /// otherwise every thread get's his own instance.
+            /// </summary>
+            public bool UseThreadInstances { get; set; } = DefaultUseThreadInstances;
+
+            /// <summary>
+            /// Global culture
+            /// </summary>
+            public CultureInfo Culture
+            {
+                get
+                {
+                    return _culture;
+                }
+                set
+                {
+                    if(_culture != value)
+                    {
+                        _culture = value;
+
+                        foreach (var instance in GetDictionaries())
+                            instance.Dispatcher.BeginInvoke(new Action(() => instance.Culture = _culture));
+                    }
+                }
+            }
+
+            /// <summary>
+            /// A flag to disable the caching logic
+            /// </summary>
+            public bool DisableCache
+            {
+                get
+                {
+                    return _disableCache;
+                }
+                set
+                {
+                    if(_disableCache != value)
+                    {
+                        _disableCache = value;
+
+                        foreach (var instance in GetDictionaries())
+                            instance.Dispatcher.BeginInvoke(new Action(() => instance.DisableCache = _disableCache));
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Determines, if the <see cref="LocalizeDictionary.MergedAvailableCultures"/> contains the invariant culture.
+            /// </summary>
+            public bool IncludeInvariantCulture
+            {
+                get
+                {
+                    return _includeInvariantCulture;
+                }
+                set
+                {
+                    if (_includeInvariantCulture != value)
+                    {
+                        _includeInvariantCulture = value;
+
+                        foreach (var instance in GetDictionaries())
+                            instance.Dispatcher.BeginInvoke(new Action(() => instance.IncludeInvariantCulture = _includeInvariantCulture));
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Determines, if missing keys should be output.
+            /// </summary>
+            public bool OutputMissingKeys
+            {
+                get
+                {
+                    return _outputMissingKeys;
+                }
+                set
+                {
+                    if(_outputMissingKeys != value)
+                    {
+                        _outputMissingKeys = value;
+
+                        foreach (var instance in GetDictionaries())
+                            instance.Dispatcher.BeginInvoke(new Action(() => instance.OutputMissingKeys = _outputMissingKeys));
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Holds the separation char/string.
+            /// </summary>
+            public string Separation
+            {
+                get
+                {
+                    return _separation;
+                }
+                set
+                {
+                    if(_separation != value)
+                    {
+                        _separation = value;
+
+                        foreach (var instance in GetDictionaries())
+                            instance.Dispatcher.BeginInvoke(new Action(() => instance.Separation = _separation));
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Holds the default localization provider type
+            /// This type has to implementd <see cref="ILocalizationProvider"/>
+            /// </summary>
+            public Type LocalizationProviderType
+            {
+                get
+                {
+                    return _LocalizationProviderType;
+                }
+                set
+                {
+                    if (value != null)
+                    {
+                        if (typeof(ILocalizationProvider).IsAssignableFrom(value))
+                            _LocalizationProviderType = value;
+                        else
+                            throw new NotSupportedException($"The type {value} can't be used as {nameof(LocalizationProviderType)}, it has to implement the interface {nameof(ILocalizationProvider)}!");
+                    }
+                    else
+                        _LocalizationProviderType = DefaultLocalizatinProviderType;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets a flag that determines, if the CurrentThread culture should be changed along with the Culture property.
+            /// </summary>
+            public bool SetCurrentThreadCulture
+            {
+                get
+                {
+                    return _setCurrentThreadCulture;
+                }
+                set
+                {
+                    if(value != _setCurrentThreadCulture)
+                    {
+                        _setCurrentThreadCulture = value;
+
+                        foreach (var instance in GetDictionaries())
+                            instance.Dispatcher.BeginInvoke(new Action(() => instance.SetCurrentThreadCulture = _setCurrentThreadCulture));
+                    }
+                }
+            }
+            #endregion
+
+            #region Helper
+            private List<LocalizeDictionary> GetDictionaries()
+            {
+                return InstanceLocator.GetTypeInstances<LocalizeDictionary>().Select(x => x.Value as LocalizeDictionary).ToList();
+            }
+
+
+            #endregion
+        }
+        #endregion
+    }
+}

--- a/src/Providers/CSVEmbeddedLocalizationProvider.cs
+++ b/src/Providers/CSVEmbeddedLocalizationProvider.cs
@@ -26,7 +26,7 @@ namespace WPFLocalizeExtension.Providers
     /// <summary>
     /// A singleton CSV provider that uses attached properties and the Parent property to iterate through the visual tree.
     /// </summary>
-    public class CSVEmbeddedLocalizationProvider : CSVLocalizationProviderBase
+    public class CSVEmbeddedLocalizationProvider : CSVLocalizationProviderBase, ILocalizeInstance
     {
         #region Dependency Properties
         /// <summary>
@@ -117,40 +117,20 @@ namespace WPFLocalizeExtension.Providers
 
         #region Singleton Variables, Properties & Constructor
         /// <summary>
-        /// The instance of the singleton.
-        /// </summary>
-        private static CSVEmbeddedLocalizationProvider _instance;
-
-        /// <summary>
-        /// Lock object for the creation of the singleton instance.
-        /// </summary>
-        private static readonly object InstanceLock = new object();
-
-        /// <summary>
         /// Gets the <see cref="CSVEmbeddedLocalizationProvider"/> singleton.
         /// </summary>
         public static CSVEmbeddedLocalizationProvider Instance
         {
             get
             {
-                if (_instance == null)
-                {
-                    lock (InstanceLock)
-                    {
-                        if (_instance == null)
-                            _instance = new CSVEmbeddedLocalizationProvider();
-                    }
-                }
-
-                // return the existing/new instance
-                return _instance;
+                return InstanceLocator.Resolve<CSVEmbeddedLocalizationProvider>();
             }
         }
 
         /// <summary>
-        /// The singleton constructor.
+        /// The instance constructor.
         /// </summary>
-        private CSVEmbeddedLocalizationProvider()
+        public CSVEmbeddedLocalizationProvider()
         {
             ResourceManagerList = new Dictionary<string, ResourceManager>();
             AvailableCultures = new ObservableCollection<CultureInfo> { CultureInfo.InvariantCulture };

--- a/src/Providers/CSVLocalizationProvider.cs
+++ b/src/Providers/CSVLocalizationProvider.cs
@@ -21,7 +21,7 @@ namespace WPFLocalizeExtension.Providers
     /// <summary>
     /// A singleton CSV provider that uses attached properties and the Parent property to iterate through the visual tree.
     /// </summary>
-    public class CSVLocalizationProvider : CSVLocalizationProviderBase
+    public class CSVLocalizationProvider : CSVLocalizationProviderBase, ILocalizeInstance
     {
         #region Dependency Properties
         /// <summary>
@@ -82,40 +82,20 @@ namespace WPFLocalizeExtension.Providers
 
         #region Singleton Variables, Properties & Constructor
         /// <summary>
-        /// The instance of the singleton.
-        /// </summary>
-        private static CSVLocalizationProvider _instance;
-
-        /// <summary>
-        /// Lock object for the creation of the singleton instance.
-        /// </summary>
-        private static readonly object InstanceLock = new object();
-
-        /// <summary>
         /// Gets the <see cref="CSVLocalizationProvider"/> singleton.
         /// </summary>
         public static CSVLocalizationProvider Instance
         {
             get
             {
-                if (_instance == null)
-                {
-                    lock (InstanceLock)
-                    {
-                        if (_instance == null)
-                            _instance = new CSVLocalizationProvider();
-                    }
-                }
-
-                // return the existing/new instance
-                return _instance;
+                return InstanceLocator.Resolve<CSVLocalizationProvider>();
             }
         }
 
         /// <summary>
-        /// The singleton constructor.
+        /// The instance constructor.
         /// </summary>
-        private CSVLocalizationProvider()
+        public CSVLocalizationProvider()
         {
             AvailableCultures = new ObservableCollection<CultureInfo> { CultureInfo.InvariantCulture };
         }

--- a/src/Providers/InheritingResxLocalizationProvider.cs
+++ b/src/Providers/InheritingResxLocalizationProvider.cs
@@ -14,13 +14,14 @@ namespace WPFLocalizeExtension.Providers
     using System.Globalization;
     using System.Resources;
     using System.Windows;
+    using WPFLocalizeExtension.Engine;
     using XAMLMarkupExtensions.Base;
     #endregion
 
     /// <summary>
     /// A singleton RESX provider that uses inheriting attached properties.
     /// </summary>
-    public class InheritingResxLocalizationProvider : ResxLocalizationProviderBase
+    public class InheritingResxLocalizationProvider : ResxLocalizationProviderBase, ILocalizeInstance
     {
         #region Dependency Properties
         /// <summary>
@@ -104,40 +105,20 @@ namespace WPFLocalizeExtension.Providers
 
         #region Singleton Variables, Properties & Constructor
         /// <summary>
-        /// The instance of the singleton.
-        /// </summary>
-        private static InheritingResxLocalizationProvider _instance;
-
-        /// <summary>
-        /// Lock object for the creation of the singleton instance.
-        /// </summary>
-        private static readonly object InstanceLock = new object();
-
-        /// <summary>
         /// Gets the <see cref="ResxLocalizationProvider"/> singleton.
         /// </summary>
         public static InheritingResxLocalizationProvider Instance
         {
             get
             {
-                if (_instance == null)
-                {
-                    lock (InstanceLock)
-                    {
-                        if (_instance == null)
-                            _instance = new InheritingResxLocalizationProvider();
-                    }
-                }
-
-                // return the existing/new instance
-                return _instance;
+                return InstanceLocator.Resolve<InheritingResxLocalizationProvider>();
             }
         }
 
         /// <summary>
-        /// The singleton constructor.
+        /// The instance constructor.
         /// </summary>
-        private InheritingResxLocalizationProvider()
+        public InheritingResxLocalizationProvider()
         {
             ResourceManagerList = new Dictionary<string, ResourceManager>();
             AvailableCultures = new ObservableCollection<CultureInfo> { CultureInfo.InvariantCulture };

--- a/src/Providers/ResxLocalizationProvider.cs
+++ b/src/Providers/ResxLocalizationProvider.cs
@@ -21,7 +21,7 @@ namespace WPFLocalizeExtension.Providers
     /// <summary>
     /// A singleton RESX provider that uses attached properties and the Parent property to iterate through the visual tree.
     /// </summary>
-    public class ResxLocalizationProvider : ResxLocalizationProviderBase
+    public class ResxLocalizationProvider : ResxLocalizationProviderBase, ILocalizeInstance
     {
         #region Dependency Properties
         /// <summary>
@@ -176,41 +176,13 @@ namespace WPFLocalizeExtension.Providers
 
         #region Singleton Variables, Properties & Constructor
         /// <summary>
-        /// The instance of the singleton.
-        /// </summary>
-        private static ResxLocalizationProvider _instance;
-
-        /// <summary>
-        /// Lock object for the creation of the singleton instance.
-        /// </summary>
-        private static readonly object InstanceLock = new object();
-
-        /// <summary>
         /// Gets the <see cref="ResxLocalizationProvider"/> singleton.
         /// </summary>
         public static ResxLocalizationProvider Instance
         {
             get
             {
-                if (_instance == null)
-                {
-                    lock (InstanceLock)
-                    {
-                        if (_instance == null)
-                            _instance = new ResxLocalizationProvider();
-                    }
-                }
-
-                // return the existing/new instance
-                return _instance;
-            }
-
-            set
-            {
-                lock (InstanceLock)
-                {
-                    _instance = value;
-                }
+				return InstanceLocator.Resolve<ResxLocalizationProvider>();
             }
         }
 
@@ -219,16 +191,23 @@ namespace WPFLocalizeExtension.Providers
         /// </summary>
         public static void Reset()
         {
-            Instance = null;
+            var instance = Instance;
+            InstanceLocator.Dissolve(instance);
+            instance = null;
         }
 
         /// <summary>
-        /// The singleton constructor.
+        /// The instance constructor.
         /// </summary>
-        protected ResxLocalizationProvider()
+        public ResxLocalizationProvider()
         {
             ResourceManagerList = new Dictionary<string, ResourceManager>();
             AvailableCultures = new ObservableCollection<CultureInfo> { CultureInfo.InvariantCulture };
+        }
+
+        ~ResxLocalizationProvider()
+        {
+            InstanceLocator.Dissolve(this);
         }
         #endregion
 


### PR DESCRIPTION
[#189](https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension/issues/189)

When it comes to bigger ui multi-threaded applications the WPFLocalizationExtension is losing a lot of performance on cross thread calls while `ILocalizationProvider.ProviderChanged` is called.

Therefor I implemented a new feature to use an instance per thread and not a singleton instance.

As long as `LocalizeSettings.Instance.UseThreadInstances` isn't activated the program will do the same as before and use a singleton instance.
When the flag is activated you'll get a instance per thread for the LocalizeDictionary and all Providers. You should be using the `LocalizeSettings.Instance` instead of `LocalizeDictionary.Instance` to change settings, like the current culture, for all instances.
