### PR TITLE
Multipbinding support for Loc

### DIFF
--- a/docs/Localize.md
+++ b/docs/Localize.md
@@ -53,6 +53,25 @@ the extensions support to add the Binding as Constructor. Because of WPF restric
 {lex:Loc {Binding Path=Foo}}
 ```
 
+or via content
+
+```xaml
+<lex:Loc>
+    <Binding Path="Foo" "/>
+</lex:Loc>
+```
+
+Multibinding only possible via content please use the following syntax:
+
+```xaml
+<lex:Loc>
+    <MultiBinding Converter="FooAndBarConverter">
+        <Binding Path="Foo" "/>
+        <Binding Path="Bar" "/>
+    </MultiBinding>
+</lex:Loc>
+```
+
 This gives you the full flexibility because the Markupextensions is the pure Binding and this supports Converters, StringFormat, ...
 
 ### Enums
@@ -89,6 +108,6 @@ For translation of complex texts there some value should be in the text like thi
 
 >You have selected 10 car(s).
 
-TWe have introduces a StringFormatConverter see [ValueConverters](ValueConverters.md) with automatic using of [smartFormat](https://github.com/axuno/SmartFormat) if this is available.
+We have introduced a StringFormatConverter see [ValueConverters](ValueConverters.md) with automatic using of [smartFormat](https://github.com/axuno/SmartFormat) if this is available.
 A detailed explanation how to use can be found [here](GapText.md). 
 

--- a/src/Deprecated/Engine/LocBinding.cs
+++ b/src/Deprecated/Engine/LocBinding.cs
@@ -45,11 +45,11 @@ namespace WPFLocalizeExtension.Deprecated.Engine
         #endregion
 
         #region Target LocExtension
-        private LocExtension _target;
+        private LocBaseExtension _target;
         /// <summary>
         /// The target extension.
         /// </summary>
-        public LocExtension Target
+        public LocBaseExtension Target
         {
             get => _target;
             set

--- a/src/Deprecated/Engine/LocProxy.cs
+++ b/src/Deprecated/Engine/LocProxy.cs
@@ -22,9 +22,9 @@ namespace WPFLocalizeExtension.Deprecated.Engine
     public class LocProxy : FrameworkElement
     {
         /// <summary>
-        /// Our own <see cref="LocExtension"/> instance.
+        /// Our own <see cref="LocBaseExtension"/> instance.
         /// </summary>
-        private LocExtension _ext;
+        private LocBaseExtension _ext;
 
         #region Source property
         /// <summary>
@@ -133,7 +133,7 @@ namespace WPFLocalizeExtension.Deprecated.Engine
 
                     if (proxy._ext == null)
                     {
-                        proxy._ext = new LocExtension { Key = key };
+                        proxy._ext = new LocBaseExtension { Key = key };
                         proxy._ext.SetBinding(proxy, proxy.GetType().GetProperty("Result"));
                     }
                     else

--- a/src/Deprecated/Extensions/Compatibility.cs
+++ b/src/Deprecated/Extensions/Compatibility.cs
@@ -20,7 +20,7 @@ namespace WPFLocalizeExtension.Deprecated.Extensions
     /// <inheritdoc/>
     [Obsolete("LocBrushExtension is deprecated and will be removed in version 4.0, please use lex:Loc instead and see documentation", false)]
     [MarkupExtensionReturnType(typeof(System.Windows.Media.Brush))]
-    public class LocBrushExtension : LocExtension
+    public class LocBrushExtension : LocBaseExtension
     {
         /// <inheritdoc/>
         public LocBrushExtension()
@@ -33,7 +33,7 @@ namespace WPFLocalizeExtension.Deprecated.Extensions
     /// <inheritdoc/>
     [Obsolete("LocDoubleExtension is deprecated and will be removed in version 4.0, please use lex:Loc instead and see documentation", false)]
     [MarkupExtensionReturnType(typeof(double))]
-    public class LocDoubleExtension : LocExtension
+    public class LocDoubleExtension : LocBaseExtension
     {
         /// <inheritdoc/>
         public LocDoubleExtension()
@@ -46,7 +46,7 @@ namespace WPFLocalizeExtension.Deprecated.Extensions
     /// <inheritdoc/>
     [MarkupExtensionReturnType(typeof(System.Windows.FlowDirection))]
     [Obsolete("LocFlowDirectionExtension is deprecated and will be removed in version 4.0, please use lex:Loc instead and see documentation", false)]
-    public class LocFlowDirectionExtension : LocExtension
+    public class LocFlowDirectionExtension : LocBaseExtension
     {
         /// <inheritdoc/>
         public LocFlowDirectionExtension()
@@ -59,7 +59,7 @@ namespace WPFLocalizeExtension.Deprecated.Extensions
     /// <inheritdoc/>
     [MarkupExtensionReturnType(typeof(System.Windows.Media.Imaging.BitmapSource))]
     [Obsolete("LocImageExtension is deprecated and will be removed in version 4.0, please use lex:Loc instead and see documentation", false)]
-    public class LocImageExtension : LocExtension
+    public class LocImageExtension : LocBaseExtension
     {
         /// <inheritdoc/>
         public LocImageExtension()
@@ -72,7 +72,7 @@ namespace WPFLocalizeExtension.Deprecated.Extensions
     /// <inheritdoc/>
     [MarkupExtensionReturnType(typeof(string))]
     [Obsolete("LocTextExtension is deprecated and will be removed in version 4.0, please use lex:Loc instead and see documentation", false)]
-    public class LocTextExtension : LocExtension
+    public class LocTextExtension : LocBaseExtension
     {
         #region Constructors
         /// <inheritdoc/>
@@ -323,7 +323,7 @@ namespace WPFLocalizeExtension.Deprecated.Extensions
     /// <inheritdoc/>
     [MarkupExtensionReturnType(typeof(System.Windows.Thickness))]
     [Obsolete("LocThicknessExtension is deprecated and will be removed in version 4.0, please use lex:Loc instead and see documentation", false)]
-    public class LocThicknessExtension : LocExtension
+    public class LocThicknessExtension : LocBaseExtension
     {
         /// <inheritdoc/>
         public LocThicknessExtension()

--- a/src/Deprecated/Extensions/LocExtension.cs
+++ b/src/Deprecated/Extensions/LocExtension.cs
@@ -1,0 +1,23 @@
+﻿#region Copyright information
+// <copyright file="LocExtension.cs">
+//     Licensed under Microsoft Public License (Ms-PL)
+//     https://github.com/XAMLMarkupExtensions/WPFLocalizationExtension/blob/master/LICENSE
+// </copyright>
+// <author>Konrad Mattheis</author>
+#endregion
+
+namespace WPFLocalizeExtension.Deprecated.Extensions
+{
+    using System.Windows.Markup;
+
+    /// <inheritdoc/>>
+    [ContentProperty("ResourceIdentifierKey")]
+    public class LocExtension : WPFLocalizeExtension.Extensions.LocBaseExtension
+    {
+        /// <inheritdoc/>>
+        public LocExtension() : base() { }
+
+        /// <inheritdoc/>>
+        public LocExtension(object key) : base(key) { }
+    }
+}

--- a/src/Engine/EnumRun.cs
+++ b/src/Engine/EnumRun.cs
@@ -22,9 +22,9 @@ namespace WPFLocalizeExtension.Engine
     public class EnumRun : Run
     {
         /// <summary>
-        /// Our own <see cref="LocExtension"/> instance.
+        /// Our own <see cref="LocBaseExtension"/> instance.
         /// </summary>
-        private LocExtension _ext;
+        private LocBaseExtension _ext;
 
         #region EnumValue property
         /// <summary>
@@ -116,7 +116,7 @@ namespace WPFLocalizeExtension.Engine
 
                     if (run._ext == null)
                     {
-                        run._ext = new LocExtension { Key = key };
+                        run._ext = new LocBaseExtension { Key = key };
                         run._ext.SetBinding(run, run.GetType().GetProperty("Text"));
                     }
                     else

--- a/src/Engine/LocalizeDictionary.cs
+++ b/src/Engine/LocalizeDictionary.cs
@@ -501,7 +501,7 @@ namespace WPFLocalizeExtension.Engine
         /// </summary>
         ~LocalizeDictionary()
         {
-            LocExtension.ClearResourceBuffer();
+            LocBaseExtension.ClearResourceBuffer();
             FELoc.ClearResourceBuffer();
             BLoc.ClearResourceBuffer();
         }

--- a/src/Extensions/LocExtension.cs
+++ b/src/Extensions/LocExtension.cs
@@ -24,6 +24,7 @@ namespace WPFLocalizeExtension.Extensions
     using System.Windows.Media;
     using System.Windows.Media.Imaging;
     using System.Windows.Media.Media3D;
+    using WPFLocalizeExtension.Deprecated.Engine;
     using WPFLocalizeExtension.Engine;
     using WPFLocalizeExtension.Providers;
     using WPFLocalizeExtension.TypeConverters;
@@ -33,8 +34,7 @@ namespace WPFLocalizeExtension.Extensions
     /// <summary>
     /// A generic localization extension.
     /// </summary>
-    [ContentProperty("ResourceIdentifierKey")]
-    public class LocExtension : NestedMarkupExtension, INotifyPropertyChanged, IDictionaryEventListener, IDisposable
+    public abstract class LocBaseExtension : NestedMarkupExtension, INotifyPropertyChanged, IDictionaryEventListener, IDisposable
     {
         #region PropertyChanged Logic
         /// <summary>
@@ -150,9 +150,9 @@ namespace WPFLocalizeExtension.Extensions
         /// <param name="property">The target property name.</param>
         /// <param name="propertyIndex">The index in the property (if applicable).</param>
         /// <returns>The bound extension or null, if not available.</returns>
-        public static LocExtension GetBoundExtension(object target, string property, int propertyIndex = -1)
+        public static LocBaseExtension GetBoundExtension(object target, string property, int propertyIndex = -1)
         {
-            foreach (var ext in LocalizeDictionary.DictionaryEvent.EnumerateListeners<LocExtension>())
+            foreach (var ext in LocalizeDictionary.DictionaryEvent.EnumerateListeners<LocBaseExtension>())
             {
                 var ep = ext._lastEndpoint;
 
@@ -200,7 +200,7 @@ namespace WPFLocalizeExtension.Extensions
 
         #region Properties
         /// <summary>
-        /// Gets or sets the Key to a .resx object
+        /// Gets or sets the Key that identifies a resource (Assembly:Dictionary:Key)
         /// </summary>
         public string Key
         {
@@ -210,6 +210,24 @@ namespace WPFLocalizeExtension.Extensions
                 if (_key != value)
                 {
                     _key = value;
+                    UpdateNewValue();
+
+                    OnNotifyPropertyChanged(nameof(Key));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the Binding that delivers the Key that identifies a resource (Assembly:Dictionary:Key)
+        /// </summary>
+        public BindingBase KeyBinding
+        {
+            get => _binding;
+            set 
+            {
+                if (_binding != value)
+                {
+                    _binding = value;
                     UpdateNewValue();
 
                     OnNotifyPropertyChanged(nameof(Key));
@@ -259,18 +277,18 @@ namespace WPFLocalizeExtension.Extensions
         /// Gets or sets the Key that identifies a resource (Assembly:Dictionary:Key)
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public BindingBase ResourceIdentifierKey
+        public object ResourceIdentifierKey
         {
-            get => _binding;
-            set => _binding = value;
+            get => _key ?? "(null)";
+            set => _key = value.ToString();
         }
         #endregion
 
         #region Constructors & Dispose
         /// <summary>
-        /// Initializes a new instance of the <see cref="LocExtension"/> class.
+        /// Initializes a new instance of the <see cref="LocBaseExtension"/> class.
         /// </summary>
-        public LocExtension()
+        public LocBaseExtension()
         {
             // Register this extension as an event listener on the first target.
             OnFirstTarget = () =>
@@ -280,10 +298,10 @@ namespace WPFLocalizeExtension.Extensions
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="LocExtension"/> class.
+        /// Initializes a new instance of the <see cref="LocBaseExtension"/> class.
         /// </summary>
         /// <param name="key">The resource identifier.</param>
-        public LocExtension(object key)
+        public LocBaseExtension(object key)
             : this()
         {
             if (key is TemplateBindingExpression tbe)
@@ -317,7 +335,7 @@ namespace WPFLocalizeExtension.Extensions
         /// <summary>
         /// The finalizer.
         /// </summary>
-        ~LocExtension()
+        ~LocBaseExtension()
         {
             Dispose();
         }
@@ -476,13 +494,13 @@ namespace WPFLocalizeExtension.Extensions
                     {
                         MethodInfo mi = typeof(DependencyProperty).GetMethod("FromName", BindingFlags.Static | BindingFlags.NonPublic);
 
-                        cacheDPThis = mi.Invoke(null, new object[] { name, typeof(LocExtension) }) as DependencyProperty
-                            ?? DependencyProperty.RegisterAttached(name, typeof(NestedMarkupExtension), typeof(LocExtension),
+                        cacheDPThis = mi.Invoke(null, new object[] { name, typeof(LocBaseExtension) }) as DependencyProperty
+                            ?? DependencyProperty.RegisterAttached(name, typeof(NestedMarkupExtension), typeof(LocBaseExtension),
                                            new PropertyMetadata(null));
 
-                        cacheDPKey = mi.Invoke(null, new object[] { name + ".Key", typeof(LocExtension) }) as DependencyProperty
-                            ?? DependencyProperty.RegisterAttached(name + ".Key", typeof(string), typeof(LocExtension),
-                                            new PropertyMetadata("", (d, e) => { (d?.GetValue(cacheDPThis) as LocExtension)?.UpdateNewValue(); }));
+                        cacheDPKey = mi.Invoke(null, new object[] { name + ".Key", typeof(LocBaseExtension) }) as DependencyProperty
+                            ?? DependencyProperty.RegisterAttached(name + ".Key", typeof(string), typeof(LocBaseExtension),
+                                            new PropertyMetadata("", (d, e) => { (d?.GetValue(cacheDPThis) as LocBaseExtension)?.UpdateNewValue(); }));
                         cacheDPName = name;
                     }
 

--- a/src/Extensions/LocExtension.cs
+++ b/src/Extensions/LocExtension.cs
@@ -68,7 +68,7 @@ namespace WPFLocalizeExtension.Extensions
         /// <summary>
         /// Holds the Binding to get the key
         /// </summary>
-        private Binding _binding;
+        private BindingBase _binding;
 
         /// <summary>
         /// the Name of the cached dynamic generated DependencyProperties
@@ -259,10 +259,10 @@ namespace WPFLocalizeExtension.Extensions
         /// Gets or sets the Key that identifies a resource (Assembly:Dictionary:Key)
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public object ResourceIdentifierKey
+        public BindingBase ResourceIdentifierKey
         {
-            get => _key ?? "(null)";
-            set => _key = value.ToString();
+            get => _binding;
+            set => _binding = value;
         }
         #endregion
 
@@ -298,7 +298,7 @@ namespace WPFLocalizeExtension.Extensions
                 key = newBinding;
             }
 
-            if (key is Binding binding)
+            if (key is BindingBase binding)
                 _binding = binding;
             else
                 Key = key?.ToString();

--- a/src/ValueConverters/TranslateConverter.cs
+++ b/src/ValueConverters/TranslateConverter.cs
@@ -54,7 +54,7 @@ namespace WPFLocalizeExtension.ValueConverters
                     culture = LocalizeDictionary.Instance.SpecificCulture;
                     var _key = value.ToString();
 
-                    var result = LocExtension.GetLocalizedValue(targetType, _key, culture, null);
+                    var result = LocBaseExtension.GetLocalizedValue(targetType, _key, culture, null);
 
                     if (result == null)
                     {

--- a/tests/HelloWorldWPF/MainWindow.xaml
+++ b/tests/HelloWorldWPF/MainWindow.xaml
@@ -74,6 +74,15 @@
             </Button.Template>
         </Button>
         <TextBlock Text="{lex:Loc {Binding tenum, StringFormat=TestEnum_{0}}}"></TextBlock>
+        <TextBlock>
+            <TextBlock.Text>
+                <lex:Loc>
+                    <MultiBinding StringFormat="{}{0}">
+                        <Binding Path="tenum" StringFormat="TestEnum_{0}"/>
+                    </MultiBinding>
+                </lex:Loc>
+            </TextBlock.Text>
+        </TextBlock>
         <TextBlock Text="{lex:Loc {Binding tenum, Converter={lex:PrependTypeConverter}, ConverterParameter=__}}"></TextBlock>
         <Button Name="BindeTestButton" Content="Press to toggle binded property" Margin="5" Click="BindeTestButton_Click" ></Button>
         <TextBlock Name="MyLabel2" FontSize="20" Text="{lex:Loc PresentationCore:ExceptionStringTable:DeleteText}" HorizontalAlignment="Center" />

--- a/tests/HelloWorldWPF/MainWindow.xaml
+++ b/tests/HelloWorldWPF/MainWindow.xaml
@@ -78,7 +78,7 @@
             <TextBlock.Text>
                 <lex:Loc>
                     <MultiBinding StringFormat="{}{0}">
-                        <Binding Path="tenum" StringFormat="TestEnum_{0}"/>
+                        <Binding Path="tenum"  Converter="{lex:PrependTypeConverter}" ConverterParameter="__"/>
                     </MultiBinding>
                 </lex:Loc>
             </TextBlock.Text>

--- a/tests/HelloWorldWPF/MainWindow.xaml
+++ b/tests/HelloWorldWPF/MainWindow.xaml
@@ -8,6 +8,7 @@
         xmlns:local="clr-namespace:HalloWeltWPF"
         d:DataContext="{d:DesignInstance Type=local:TestVM, IsDesignTimeCreatable=True}" 
         mc:Ignorable="d"
+
         lex:LocalizeDictionary.DesignCulture="en"
         lex:LocalizeDictionary.IncludeInvariantCulture="False"
         lex:ResxLocalizationProvider.DefaultAssembly="HelloWorldWPF"
@@ -77,9 +78,12 @@
         <TextBlock>
             <TextBlock.Text>
                 <lex:Loc>
-                    <MultiBinding StringFormat="{}{0}">
-                        <Binding Path="tenum"  Converter="{lex:PrependTypeConverter}" ConverterParameter="__"/>
-                    </MultiBinding>
+                    en
+                    <!--<lex:Loc.KeyBinding>-->
+                        <!--<MultiBinding StringFormat="{}{0}">
+                            <Binding Path="tenum"  Converter="{lex:PrependTypeConverter}" ConverterParameter="__"/>
+                        </MultiBinding>-->
+                    <!--</lex:Loc.KeyBinding>-->
                 </lex:Loc>
             </TextBlock.Text>
         </TextBlock>


### PR DESCRIPTION
This small change have a small breaking change and for me a huge benefit:

breaks:
`<lex:Loc>keyName</lex:Loc>`

feature:
```xml
 <TextBlock>
        <TextBlock.Text>
            <lex:Loc>
                <MultiBinding Converter="...">
                    <Binding Path="PATH" "/>
                </MultiBinding>
            </lex:Loc>
        </TextBlock.Text>
</TextBlock>
```